### PR TITLE
Add --lai option to output tile-resolution ancestry inferences

### DIFF
--- a/ntroot
+++ b/ntroot
@@ -39,6 +39,8 @@ def set_up_parser():
                         required=True, type=int)
     parser.add_argument("--tile", help="Tile size for ancestry fraction inference (bp) [default=5000000]",
                         default=5000000, type=int)
+    parser.add_argument("--lai", help="Output ancestry predictons per tile in a separate output file",
+                        action="store_true")
     parser.add_argument("-t",
                         help="Number of threads [default=4]", default=4, type=int)
     parser.add_argument("-z",
@@ -77,9 +79,15 @@ def main():
                     "Parameter settings:"]
 
     if args.reads:
-        smk_rule = "ntroot_reads"
+        if args.lai:
+            smk_rule = "ntroot_reads_lai"
+        else:
+            smk_rule = "ntroot_reads"
     if args.genome:
-        smk_rule = "ntroot_genome"
+        if args.lai:
+            smk_rule = "ntroot_genome_lai"
+        else:
+            smk_rule = "ntroot_genome"
 
     command = f"snakemake -s {base_dir}/ntroot_run_pipeline.smk {smk_rule} --nolock -p --cores {args.t} " \
             f"--config draft={args.draft} k={args.k} t={args.t} " \
@@ -100,7 +108,9 @@ def main():
                         f"\t-j {args.j}",
                         f"\t-Y {args.Y}"
                     ])
-
+    
+    if args.lai:
+        intro_string.append("\t--lai")
 
     if args.verbose:
         intro_string.append("\t-v")


### PR DESCRIPTION
* Added `--lai` option to `ntroot` to output ancestry inference and scores per tile
* Example of new output file:
```
(btl) [lcoombe@hpce706 18Mar2024]$ head KOREFformatted_copy1_ntedit_k55_variants.vcf_ancestry-predictions-tile-resolution_tile5000000.tsv |cat_col
chrom  start      end        ancestry_prediction  AFR-score  AMR-score  EAS-score  EUR-score  SAS-score
X      1          5000000    EAS                  0.0172     0.0175     0.0199     0.0164     0.0180
X      155000001  156040895  EAS                  0.0233     0.0211     0.0264     0.0190     0.0209
1      1          5000000    EAS                  0.0181     0.0188     0.0220     0.0172     0.0190
1      5000001    10000000   EAS                  0.0201     0.0201     0.0235     0.0189     0.0194
1      10000001   15000000   EAS                  0.0180     0.0179     0.0199     0.0171     0.0185
1      15000001   20000000   EAS                  0.0193     0.0214     0.0244     0.0208     0.0208
1      20000001   25000000   EAS                  0.0195     0.0217     0.0244     0.0209     0.0221
1      25000001   30000000   EAS                  0.0185     0.0192     0.0233     0.0172     0.0198
1      30000001   35000000   EAS                  0.0178     0.0191     0.0220     0.0182     0.0193
```
* Note that this is sorting alphabetically for the populations, vs. the order currently in the paper
  * This is because I wanted to try to keep the script general (ie. not tied to the 1000 genomes super-populations) - but let me know if there is another sort approach that would be better