### PR TITLE
Update pl list

### DIFF
--- a/ntRootAncestryPredictor.pl
+++ b/ntRootAncestryPredictor.pl
@@ -98,25 +98,31 @@ while(<IN>){
 				my @d=split(/\=/,$el);
 				if($d[0]=~/(\S+)\_AF/){
 					my $pop=$1;
-					if (! defined $populations->{$pop}) {
-						$populations->{$pop} = 1;
-					}
-					$s->{$d[0]}{'sum'}+=$d[1];
-
-					#chr  winnum   pop
-					$z->{$a[0]}{$wn}{$pop}{'sum'}+=$d[1];
-					$y->{$a[0]}{$wn}{'ct'}++;
-
-
-					if($d[1]){
-						$s->{$d[0]}{'ct'}++;
-						$z->{$a[0]}{$wn}{$pop}{'nzct'}++;
-						if($a[1]>$max){
-							$max=$a[1];
-							$maxpop=$pop;
+					my @alleles = split(/,/,$d[1]);
+					foreach my $allele(@alleles){
+						if ($allele !~ /\d+/) {
+							next;
 						}
-					} else{
-						$d[1]=1;
+						if (! defined $populations->{$pop}) {
+							$populations->{$pop} = 1;
+						}
+						$s->{$d[0]}{'sum'}+=$allele;
+
+						#chr  winnum   pop
+						$z->{$a[0]}{$wn}{$pop}{'sum'}+=$allele;
+						$y->{$a[0]}{$wn}{'ct'}++;
+
+
+						if($allele){
+							$s->{$d[0]}{'ct'}++;
+							$z->{$a[0]}{$wn}{$pop}{'nzct'}++;
+							if($a[1]>$max){
+								$max=$a[1];
+								$maxpop=$pop;
+							}
+						} else{
+							$allele=1;
+						}
 					}
 				}
 			}

--- a/ntRootAncestryPredictor.pl
+++ b/ntRootAncestryPredictor.pl
@@ -98,22 +98,22 @@ while(<IN>){
 				my @d=split(/\=/,$el);
 				if($d[0]=~/(\S+)\_AF/){
 					my $pop=$1;
-					my @alleles = split(/,/,$d[1]);
-					foreach my $allele(@alleles){
-						if ($allele !~ /\d+/) {
+					my @AFalleles = split(/,/,$d[1]);
+					foreach my $afallele(@AFalleles){
+						if ($afallele !~ /\d+/) {
 							next;
 						}
 						if (! defined $populations->{$pop}) {
 							$populations->{$pop} = 1;
 						}
-						$s->{$d[0]}{'sum'}+=$allele;
+						$s->{$d[0]}{'sum'}+=$afallele;
 
 						#chr  winnum   pop
-						$z->{$a[0]}{$wn}{$pop}{'sum'}+=$allele;
+						$z->{$a[0]}{$wn}{$pop}{'sum'}+=$afallele;
 						$y->{$a[0]}{$wn}{'ct'}++;
 
 
-						if($allele){
+						if($afallele){
 							$s->{$d[0]}{'ct'}++;
 							$z->{$a[0]}{$wn}{$pop}{'nzct'}++;
 							if($a[1]>$max){
@@ -121,7 +121,7 @@ while(<IN>){
 								$maxpop=$pop;
 							}
 						} else{
-							$allele=1;
+							$afallele=1;
 						}
 					}
 				}


### PR DESCRIPTION
* Add support for parsing allele frequencies when multiple alt alleles are in a line.
* Example: 
```
chr1    1077150 .       A       C,G     14.02   PASS    F;AC=342,NA;AN=5096,NA;DP=9834,NA;AF=0.07,NA;EAS_AF=0.11,NA;EUR_AF=0.02,NA;AFR_AF=0.02,NA;AMR_AF=0.1,NA;SAS_AF=0.11,NA;VT=SNP,NA;NS=2548,NA;F=NA;VCF_L=NA       GT:GQ:DP:AF     1/2:14:44:0.6136
```
* If there are no commas in the value of "XX_AF", then the behaviour would stay to exactly how it was before
* If there are commas, it will iterate over those values, and add info for each alt allele (as long as the value is not NA)