### PR TITLE
Change single character keys in snakemake parameter configs to multi-character

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,16 @@ jobs:
       source activate ntroot_CI
       conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
       mamba install --yes -c conda-forge -c bioconda snakemake perl 'ntedit>=2.0.1' samtools bedtools
+      mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages
+
+  - script: |
+      source activate ntroot_CI
+      git clone https://github.com/bcgsc/ntEdit.git
+      cd ntEdit
+      meson setup build --prefix=$(pwd)/ntedit_build
+      cd build && ninja install
+    displayName: Build ntEdit (until 2.0.3 updated in conda)
   
   - script: |
       source activate ntroot_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
     displayName: Install Conda packages
 
   - script: |
+      source activate ntroot_CI
       git clone https://github.com/bcgsc/ntEdit.git
       cd ntEdit
       meson setup build --prefix=$(pwd)/ntedit_build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,12 +20,22 @@ jobs:
       source activate ntroot_CI
       conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
       mamba install --yes -c conda-forge -c bioconda meson ninja snakemake perl 'ntedit>=2.0.1' samtools bedtools
+      mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages
+
+  - script: |
+      git clone https://github.com/bcgsc/ntEdit.git
+      cd ntEdit
+      meson setup build --prefix=$(pwd)/ntedit_build
+      cd build && ninja install
+    displayName: Build ntEdit (until 2.0.3 updated in conda)
   
   - script: |
       source activate ntroot_CI
+      export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
       export PATH=$(pwd):$PATH
       which ntroot
+      which ntedit
       cd demo
       ./run_ntroot_demo.sh
     displayName: Run ntRoot test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,8 +73,10 @@ jobs:
   
   - script: |
       source activate ntroot_CI
+      export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
       export PATH=$(pwd):$PATH
       which ntroot
+      which ntedit
       cd demo
       ./run_ntroot_demo.sh
     displayName: Run ntRoot test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntroot_CI
-      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python=3.9 mamba
+      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
       mamba install --yes -c conda-forge -c bioconda meson ninja snakemake perl 'ntedit>=2.0.1' samtools bedtools
     displayName: Install Conda packages
   
@@ -47,7 +47,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntroot_CI
-      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python=3.9 mamba
+      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
       mamba install --yes -c conda-forge -c bioconda snakemake perl 'ntedit>=2.0.1' samtools bedtools
     displayName: Install Conda packages
   

--- a/ntroot
+++ b/ntroot
@@ -149,7 +149,7 @@ def main():
     if not os.path.isfile(args.l):
         raise FileNotFoundError(f"VCF file {args.l} not found")
     intro_string.append(f"\t-l {args.l}")
-    command += f" l_param={args.l}"
+    command += f" l_vcf={args.l}"
 
     print("\n".join(intro_string), flush=True)
 

--- a/ntroot
+++ b/ntroot
@@ -111,7 +111,7 @@ def main():
             smk_rule = "ntroot_input_vcf"
 
     command = f"snakemake -s {base_dir}/ntroot_run_pipeline.smk {smk_rule} --nolock -p --cores {args.t} " \
-            f"--config reference={args.reference} t={args.t} " \
+            f"--config reference={args.reference} threads={args.t} " \
             f"tile_size={args.tile} "
 
     if args.genome:
@@ -135,21 +135,21 @@ def main():
                              f"\t-z {args.z}",
                              f"\t-j {args.j}",
                              f"\t-Y {args.Y}"])
-        command += f" k={args.k} z={args.z} j={args.j} Y={args.Y}"
+        command += f" kmer={args.k} z_param={args.z} j_param={args.j} Y_param={args.Y}"
 
     if args.lai:
         intro_string.append("\t--lai")
 
     if args.verbose:
         intro_string.append("\t-v")
-        command += " v=1"
+        command += " verbose=1"
     else:
-        command += " v=0"
+        command += " verbose=0"
 
     if not os.path.isfile(args.l):
         raise FileNotFoundError(f"VCF file {args.l} not found")
     intro_string.append(f"\t-l {args.l}")
-    command += f" l={args.l}"
+    command += f" l_param={args.l}"
 
     print("\n".join(intro_string), flush=True)
 

--- a/ntroot_run_pipeline.smk
+++ b/ntroot_run_pipeline.smk
@@ -11,22 +11,22 @@ onsuccess:
 reference=config["reference"]
 draft_base = os.path.basename(os.path.realpath(reference))
 reads_prefix=config["reads"] if "reads" in config else ""
-k=config["k"] if "k" in config else None
+k=config["kmer"] if "kmer" in config else None
 
 genomes = config["genomes"] if "genomes" in config else ""
 genome_prefix = ".".join([os.path.basename(os.path.realpath(genome)).removesuffix(".fa").removesuffix(".fasta").removesuffix(".fna") for genome in genomes])
 
 # Common parameters
-t = config["t"] if "t" in config else 4
-b = config["b"] + "_" if "b" in config and config["b"] != "" else ""
+t = config["threads"] if "threads" in config else 4
+b = config["b_prefix"] + "_" if "b_prefix" in config and config["b_prefix"] != "" else ""
 
 
 # ntEdit parameters
-z = config["z"] if "z" in config else 100
-v = config["v"] if "v" in config else 0
-j = config["j"] if "j" in config else 3
-Y = config["Y"] if "Y" in config else 0.55
-l = config["l"] if "l" in config else ""
+z = config["z_param"] if "z_param" in config else 100
+v = config["verbose"] if "verbose" in config else 0
+j = config["j_param"] if "j_param" in config else 3
+Y = config["Y_param"] if "Y_param" in config else 0.55
+l = config["l_vcf"] if "l_vcf" in config else ""
 
 # Ancestry inference parameters
 tile_size = config["tile_size"] if "tile_size" in config else 5000000


### PR DESCRIPTION
* For snakemake v8.17.0+, there is an outstanding issue where it will not correctly parse single-character config parameters
* To avoid errors, change single character config parameters in `ntroot_run_pipeline.smk` to multi-character strings
  * This is under the hood, and does not change the invocation of ntroot for users
* In `azure-pipelines.yml`, temporarily build ntEdit from source
  * Needed for CI to pass until new ntEdit version is updated in bioconda