### PR TITLE
Update CI to use conda ntEdit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
   
   - script: |
       source activate ntroot_CI
-      export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
+      export PATH=$(pwd):$PATH
       which ntroot
       which ntedit
       cd demo
@@ -56,7 +56,7 @@ jobs:
   
   - script: |
       source activate ntroot_CI
-      export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
+      export PATH=$(pwd):$PATH
       which ntroot
       cd demo
       ./run_ntroot_demo.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,19 +22,10 @@ jobs:
       mamba install --yes -c conda-forge -c bioconda meson ninja snakemake perl 'ntedit>=2.0.1' samtools bedtools
       mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages
-
-  - script: |
-      source activate ntroot_CI
-      git clone https://github.com/bcgsc/ntEdit.git
-      cd ntEdit
-      meson setup build --prefix=$(pwd)/ntedit_build
-      cd build && ninja install
-    displayName: Build ntEdit (until 2.0.3 updated in conda)
   
   - script: |
       source activate ntroot_CI
       export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
-      export PATH=$(pwd):$PATH
       which ntroot
       which ntedit
       cd demo
@@ -62,21 +53,11 @@ jobs:
       mamba install --yes -c conda-forge -c bioconda snakemake perl 'ntedit>=2.0.1' samtools bedtools
       mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages
-
-  - script: |
-      source activate ntroot_CI
-      git clone https://github.com/bcgsc/ntEdit.git
-      cd ntEdit
-      meson setup build --prefix=$(pwd)/ntedit_build
-      cd build && ninja install
-    displayName: Build ntEdit (until 2.0.3 updated in conda)
   
   - script: |
       source activate ntroot_CI
       export PATH=$(pwd)/ntEdit/ntedit_build/bin:$PATH
-      export PATH=$(pwd):$PATH
       which ntroot
-      which ntedit
       cd demo
       ./run_ntroot_demo.sh
     displayName: Run ntRoot test


### PR DESCRIPTION
* Had temporarily changed CI to build ntEdit from source until ntEdit v2.0.3 was available in conda