### PR TITLE
MacOS CI Fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,16 @@ jobs:
     persistCredentials: true
     submodules: true
 
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
 
   - script: conda create --yes --quiet --name ntroot_CI
     displayName: Create Anaconda environment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ jobs:
       ~/miniforge3/bin/conda init bash
       ~/miniforge3/bin/conda init zsh
       export CONDA=$(realpath ~/miniforge3/bin)
+      conda update -n base -c conda-forge conda
       echo "##vso[task.prependpath]$CONDA"
     displayName: Install conda
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,8 @@ jobs:
     displayName: Install conda
 
   - script: |
-      conda update -n base -c conda-forge conda
+      conda list
+      which mamba
       conda create --yes --quiet --name ntroot_CI
     displayName: Create Anaconda environment
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntroot_CI
-      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
+      mamba install --yes -c conda-forge -c bioconda python
       mamba install --yes -c conda-forge -c bioconda snakemake perl 'ntedit>=2.0.1' samtools bedtools
       mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,8 +50,8 @@ jobs:
       ~/miniforge3/bin/conda init bash
       ~/miniforge3/bin/conda init zsh
       export CONDA=$(realpath ~/miniforge3/bin)
-      conda update -n base -c conda-forge conda
       echo "##vso[task.prependpath]$CONDA"
+      conda update -n base -c conda-forge conda
     displayName: Install conda
 
   - script: conda create --yes --quiet --name ntroot_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,10 +51,11 @@ jobs:
       ~/miniforge3/bin/conda init zsh
       export CONDA=$(realpath ~/miniforge3/bin)
       echo "##vso[task.prependpath]$CONDA"
-      conda update -n base -c conda-forge conda
     displayName: Install conda
 
-  - script: conda create --yes --quiet --name ntroot_CI
+  - script: |
+      conda update -n base -c conda-forge conda
+      conda create --yes --quiet --name ntroot_CI
     displayName: Create Anaconda environment
   - script: |
       source activate ntroot_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,11 +53,9 @@ jobs:
       echo "##vso[task.prependpath]$CONDA"
     displayName: Install conda
 
-  - script: |
-      conda list
-      which mamba
-      conda create --yes --quiet --name ntroot_CI
+  - script: conda create --yes --quiet --name ntroot_CI
     displayName: Create Anaconda environment
+
   - script: |
       source activate ntroot_CI
       mamba install --yes -c conda-forge -c bioconda python


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit