### PR TITLE
Fix for input VCFs which have # character in non-header lines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate ntroot_CI
-      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python mamba
+      conda install --yes --name ntroot_CI -c conda-forge -c bioconda python=3.12 mamba
       mamba install --yes -c conda-forge -c bioconda meson ninja snakemake perl 'ntedit>=2.0.1' samtools bedtools
       mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages
@@ -58,7 +58,7 @@ jobs:
 
   - script: |
       source activate ntroot_CI
-      mamba install --yes -c conda-forge -c bioconda python
+      mamba install --yes -c conda-forge -c bioconda python=3.12
       mamba install --yes -c conda-forge -c bioconda snakemake perl 'ntedit>=2.0.1' samtools bedtools
       mamba install --yes -c conda-forge -c bioconda libcxx llvm meson ninja btllib zlib boost cmake compilers 
     displayName: Install Conda packages

--- a/ntroot_run_pipeline.smk
+++ b/ntroot_run_pipeline.smk
@@ -139,7 +139,7 @@ rule sort_vcf_input:
         benchmark = f"{time_command} sort_vcf_{input_vcf_basename}.time",
         cat_cmd = "gunzip -c" if f"{input_vcf}".endswith(".gz") else "cat"
     shell:
-        """{params.benchmark} sh -c '(echo "##fileformat=VCFv4.2" ; {params.cat_cmd} {input.vcf} |grep -v "#" |sort -k1,1 -k2,2n) > {output.vcf_sorted}'"""
+        """{params.benchmark} sh -c '(echo "##fileformat=VCFv4.2" ; {params.cat_cmd} {input.vcf} |grep -v "^#" |sort -k1,1 -k2,2n) > {output.vcf_sorted}'"""
 
 rule sort_vcf_l:
     input: vcf = l
@@ -148,7 +148,7 @@ rule sort_vcf_l:
         benchmark = f"{time_command} sort_vcf_l.time",
         cat_cmd = "gunzip -c" if f"{l}".endswith(".gz") else "cat"
     shell:
-        """{params.benchmark} sh -c "(echo '##fileformat=VCFv4.2' ; {params.cat_cmd} {input.vcf} | awk '\$5 !~ /^</' | grep -v '#' |sort -k1,1 -k2,2n) > {output}" """
+        """{params.benchmark} sh -c "(echo '##fileformat=VCFv4.2' ; {params.cat_cmd} {input.vcf} | awk '\$5 !~ /^</' | grep -v '^#' |sort -k1,1 -k2,2n) > {output}" """
 
 rule bedtools_intersect:
     input:         


### PR DESCRIPTION
* Also pin python to 3.12 in CI to avoid incompatibility errors when installing packages